### PR TITLE
Add Xcode 11 (11A420a) and 11.1 (11A1027) support

### DIFF
--- a/Kotlin.ideplugin/Contents/Info.plist
+++ b/Kotlin.ideplugin/Contents/Info.plist
@@ -42,6 +42,10 @@
 		<!-- Xcode 10.3 (10G8) -->
 		<string>B89EAABF-783E-4EBF-80D4-A9EAC69F77F2</string>
 		<string>07BAA045-2DD3-489F-B232-D1D4F8B92D2D</string>
+		<!-- Xcode 11.0 (11A420a) -->
+		<string>2FD51EF8-522D-4532-9698-980C4C497FD1</string>
+		<!-- Xcode 11.1 (11A1027) -->
+		<string>92CB09D8-3B74-4EF7-849C-99816039F0E7</string>
 	</array>
 	<key>XCPluginHasUI</key>
 	<false/>


### PR DESCRIPTION
Add Xcode 11 (11A420a) and 11.1 (11A1027) support


<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [ ] has-reproduction
- [ ] feature
- [ ] blocking
- [ ] good first review

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->