### PR TITLE
Added xcode 11.3 to supported versions

### DIFF
--- a/Kotlin.ideplugin/Contents/Info.plist
+++ b/Kotlin.ideplugin/Contents/Info.plist
@@ -48,6 +48,8 @@
 		<string>92CB09D8-3B74-4EF7-849C-99816039F0E7</string>
 		<!-- Xcode 11.2 (11B52) -->
 		<string>A74FBA51-FFEA-4409-B976-6FC3225A6F64</string>
+		<!-- Xcode 11.3 (11C29) -->
+		<string>BAB79788-ACEE-4291-826B-EC4667A6BEC5</string>
 	</array>
 	<key>XCPluginHasUI</key>
 	<false/>


### PR DESCRIPTION
Seems like the plugin works for xcode 11.3, so I added it to the supported xcode versions list.