### PR TITLE
updated script to so plugin can be reloaded after an xcode update

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -1,15 +1,39 @@
 #!/usr/bin/env bash
 
 ###################
-# PLUGINS DIRECTORY
+# DEFINITIONS
 ###################
 
+service='Xcode'
 plugins_dir=~/Library/Developer/Xcode/Plug-ins/
 
-if [ ! -d "$plugins_dir" ]; then
-	mkdir -p $plugins_dir
+###################
+# SHUT DOWN XCODE IF IT'S RUNNING
+###################
+
+if pgrep -xq -- "${service}"; then
+  echo "Xcode is running. Attempt to shut down?"
+  read answer
+  if [ "$answer" = "y" ]; then
+    echo "Shutting down Xcode"
+    pkill -x $service
+  else
+    echo "Xcode needs to be closed"
+    exit 1
+  fi
 fi
 
+###################
+
+if [ -d "${plugins_dir}Kotlin.ideplugin/" ]; then
+	echo "Plugins directory and Kotlin plugin found. Deleting..."
+  rm -rf $plugins_dir
+  open -a $service
+  pkill -x $service
+fi
+
+echo "Creating plugins directory"
+mkdir -p $plugins_dir
 cp -r Kotlin.ideplugin $plugins_dir
 
 ###################
@@ -28,3 +52,4 @@ else
 		echo $lldb_config >> ~/.lldbinit-Xcode
 		echo $lldb_format >> ~/.lldbinit-Xcode
 fi
+

--- a/setup.sh
+++ b/setup.sh
@@ -12,7 +12,7 @@ plugins_dir=~/Library/Developer/Xcode/Plug-ins/
 ###################
 
 if pgrep -xq -- "${service}"; then
-  echo "Xcode is running. Attempt to shut down?"
+  echo "Xcode is running. Attempt to shut down? y/n"
   read answer
   if [ "$answer" = "y" ]; then
     echo "Shutting down Xcode"


### PR DESCRIPTION
- [x] feature

Updated setup.sh script with the following:

- asks to close Xcode if it's open
- checks if plugin is already installed; if so, it's deleted
- open and close Xcode once without plugin installed
- create (or recreate, if just deleted) plugin directory

To use the plugin on a new version of Xcode:

- update Xcode
- run `./setup.sh` in this repo's root
- first time you open new version of Xcode, select "Load Bundle" in the popup