### PR TITLE
Use current default Xcode path when multiple Xcode installations are present

### DIFF
--- a/colorsetup-xcode11.sh
+++ b/colorsetup-xcode11.sh
@@ -4,10 +4,15 @@
 # LANGUAGE SPEC
 ###################
 
-spec_dir=/Applications/Xcode.app/Contents/SharedFrameworks/SourceModel.framework/Versions/A/Resources/LanguageSpecifications
+xcode_developer_dir=$(xcode-select --print-path)
+
+## Default is /Applications/Xcode.app/Contents
+xcode_content_dir=$(dirname "$xcode_developer_dir")
+
+spec_dir=$xcode_content_dir/SharedFrameworks/SourceModel.framework/Versions/A/Resources/LanguageSpecifications
 
 cp Kotlin.xclangspec $spec_dir
 
-meta_dir=/Applications/Xcode.app/Contents/SharedFrameworks/SourceModel.framework/Versions/A/Resources/LanguageMetadata
+meta_dir=$xcode_content_dir/SharedFrameworks/SourceModel.framework/Versions/A/Resources/LanguageMetadata
 
 cp Xcode.SourceCodeLanguage.Kotlin.plist $meta_dir


### PR DESCRIPTION
Currently hard-coded Xcode path is used during the plugin installation _(/Applications/Xcode.app)_. 
When you have multiple Xcode installations you want this plugin to be installed for ["current default Xcode"](https://developer.apple.com/library/archive/technotes/tn2339/_index.html#//apple_ref/doc/uid/DTS40014588-CH1-HOW_DO_I_SELECT_THE_DEFAULT_VERSION_OF_XCODE_TO_USE_FOR_MY_COMMAND_LINE_TOOLS_).

P.S. My main intention is to raise the issue and propose at least one solution. 
Thus feel free to do any adjustments to this PR if required  - my core expertise is rather Android then iOS.


<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [ ] has-reproduction
- [x ] feature
- [ ] blocking
- [ ] good first review

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->