### PR TITLE
Add support for Xcode 13.2.1

### DIFF
--- a/Kotlin.ideplugin/Contents/Info.plist
+++ b/Kotlin.ideplugin/Contents/Info.plist
@@ -66,6 +66,8 @@
 		<string>8BAA96B4-5225-471B-B124-D32A349B8106</string>
 		<!-- Xcode 13.2 (13C90)-->
 		<string>7A3A18B7-4C08-46F0-A96A-AB686D315DF0</string>
+		<!-- Xcode 13.2.1 (13C100)-->
+		<string>18B7-4C08-46F0-A96A-AB686D315DF0</string>
 	</array>
 	<key>XCPluginHasUI</key>
 	<false/>


### PR DESCRIPTION
Adds the UUID for Xcode 13.2.1 in order to have the plug-in working with that version of the IDE.