### PR TITLE
Automatically allow the plugin in all installed Xcodes during sync

### DIFF
--- a/src/macosMain/kotlin/co/touchlab/xcode/cli/PluginManager.kt
+++ b/src/macosMain/kotlin/co/touchlab/xcode/cli/PluginManager.kt
@@ -58,6 +58,7 @@ object PluginManager {
     fun sync(xcodeInstallations: List<XcodeHelper.XcodeInstallation>) {
         XcodeHelper.removeKotlinPluginFromDefaults()
         if (isInstalled) {
+            XcodeHelper.addKotlinPluginToDefaults(installedVersion ?: bundledVersion, xcodeInstallations)
             Console.echo("Synchronizing plugin compatibility list.")
             val additionalPluginCompatibilityIds = xcodeInstallations.map { PropertyList.Object.String(it.pluginCompatabilityId) }
             logger.v { "Xcode installation IDs to include: ${additionalPluginCompatibilityIds.joinToString { it.value }}" }

--- a/src/macosMain/kotlin/co/touchlab/xcode/cli/util/PropertyList.kt
+++ b/src/macosMain/kotlin/co/touchlab/xcode/cli/util/PropertyList.kt
@@ -51,11 +51,11 @@ class PropertyList(val root: Object) {
         val numberOrNull: Number? get() = this as? Number
 
         class Array(
-            val items: MutableList<Object>
+            val items: MutableList<Object> = mutableListOf(),
         ): Object, MutableList<Object> by items
 
         class Dictionary(
-            val items: MutableMap<kotlin.String, Object>,
+            val items: MutableMap<kotlin.String, Object> = mutableMapOf(),
         ): Object, MutableMap<kotlin.String, Object> by items
 
         class String(


### PR DESCRIPTION
<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [ ] has-reproduction
- [ ] feature
- [ ] blocking
- [ ] good first review

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->