### PR TITLE
Fix crash for Xcode 15.3

### DIFF
--- a/src/macosMain/kotlin/co/touchlab/xcode/cli/PluginManager.kt
+++ b/src/macosMain/kotlin/co/touchlab/xcode/cli/PluginManager.kt
@@ -73,7 +73,7 @@ object PluginManager {
 
         Console.echo("Synchronizing plugin compatibility list.")
         val additionalPluginCompatibilityIds =
-            xcodeInstallations.map { PropertyList.Object.String(it.pluginCompatabilityId) }
+            xcodeInstallations.mapNotNull { it.pluginCompatabilityId?.let { PropertyList.Object.String(it) } }
         logger.v { "Xcode installation IDs to include: ${additionalPluginCompatibilityIds.joinToString { it.value }}" }
         val infoPlist = PropertyList.create(pluginTargetInfoFile)
         val rootDictionary = infoPlist.root.dictionary

--- a/src/macosMain/kotlin/co/touchlab/xcode/cli/XcodeHelper.kt
+++ b/src/macosMain/kotlin/co/touchlab/xcode/cli/XcodeHelper.kt
@@ -5,9 +5,11 @@ import co.touchlab.xcode.cli.XcodeHelper.Defaults.nonApplePlugins
 import co.touchlab.xcode.cli.util.BackupHelper
 import co.touchlab.xcode.cli.util.Console
 import co.touchlab.xcode.cli.util.File
+import co.touchlab.xcode.cli.util.fromString
 import co.touchlab.xcode.cli.util.Path
 import co.touchlab.xcode.cli.util.PropertyList
 import co.touchlab.xcode.cli.util.Shell
+import co.touchlab.xcode.cli.util.Version
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
@@ -83,6 +85,14 @@ object XcodeHelper {
             checkNotNull(versionPlist.build?.trim()) { "Couldn't get build number of Xcode at $path." }
         }
 
+        if (Version.fromString(version) >= Version.fromString("15.3")) {
+            return XcodeInstallation(
+                version = version,
+                build = build,
+                path = path
+            )
+        }
+
         val xcodeInfoPath = path / "Contents" / "Info"
         val pluginCompatabilityIdResult = Shell.exec("/usr/bin/defaults", "read", xcodeInfoPath.value, "DVTPlugInCompatibilityUUID")
             .checkSuccessful {
@@ -154,7 +164,7 @@ object XcodeHelper {
         val version: String,
         val build: String,
         val path: Path,
-        val pluginCompatabilityId: String,
+        val pluginCompatabilityId: String? = null,
     ) {
         val name: String = "Xcode $version ($build)"
     }


### PR DESCRIPTION
## Summary
Since Xcode 15.3, Info.plist does not have DVTPlugInCompatibilityUUID anymore and it doesn't require to have it
<!--- Copy summary from issue link or write a shortened description of it -->

## Fix
if we detect Xcode Version > 15.3, we have early exit and do not check for DVTPlugInCompatibilityUUID inside Info.plist
<!-- What did you do to fix the issue? -->

## Pull Request Labels

<!--- While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below: -->

- [ ] has-reproduction
- [ ] feature
- [x] blocking
- [ ] good first review

<!--- To add a label not listed above, simply place `/label another-label-name` on a line by itself. -->