### PR TITLE
Fix using lower Xcode version than minimum required by macOS: _LSOpenURLsWithCompletionHandler() failed for the application /Applications/Xcode.app with error -10664.

### DIFF
--- a/src/macosMain/kotlin/co/touchlab/xcode/cli/XcodeHelper.kt
+++ b/src/macosMain/kotlin/co/touchlab/xcode/cli/XcodeHelper.kt
@@ -44,8 +44,14 @@ object XcodeHelper {
     }
 
     fun openInBackground(installation: XcodeInstallation) {
-        Shell.exec("/usr/bin/open", "-gjFa", installation.path.value).checkSuccessful {
-            "Couldn't open ${installation.name} at ${installation.path}!"
+        // Fix using lower Xcode version than minimum required by macOS:
+        // _LSOpenURLsWithCompletionHandler() failed for the application /Applications/Xcode.app with error -10664.
+        // Usage: ./build/bin/macosArm64/debugExecutable/xcode-kotlin.kexe sync /Applications/Xcode.app
+        val realXcodePath = "${installation.path.value}/Contents/MacOS/Xcode"
+        logger.i { "Opening realXcodePath in background." }
+        Console.echo("Opening realXcodePath in background.")
+        Shell.exec("/usr/bin/open", "-gjF", realXcodePath).checkSuccessful {
+            "Couldn't open ${installation.name} at $realXcodePath!"
         }
     }
 


### PR DESCRIPTION
## Summary
When using lower Xcode version than minimum required by macOS, xcode-kotlin crashed as  `_LSOpenURLsWithCompletionHandler() failed for the application /Applications/Xcode.app with error -10664.`

## Fix
<!-- What did you do to fix the issue? -->
Fix `XcodeHelper#openInBackground`: 
1. `realXcodePath`: "${installation.path.value}/Contents/MacOS/Xcode".
2. remove `-a` param of the `open` command.


Then usage:
```shell
./build/bin/macosArm64/debugExecutable/xcode-kotlin.kexe sync /Applications/Xcode.app
```

## Pull Request Labels
- [x] has-reproduction
- [ ] feature
- [ ] blocking
- [x] good first review

<!--- To add a label not listed above, simply place `/label another-label-name` on a line by itself. -->