### PR TITLE
Fix: An address is returned when the string is empty

### DIFF
--- a/LLDBPlugin/touchlab_kotlin_lldb/types/KonanStringSyntheticProvider.py
+++ b/LLDBPlugin/touchlab_kotlin_lldb/types/KonanStringSyntheticProvider.py
@@ -26,4 +26,7 @@ class KonanStringSyntheticProvider(KonanBaseSyntheticProvider):
 
     def to_string(self):
         s = kotlin_object_to_string(self._process, self._valobj.unsigned)
-        return '"{}"'.format(s) if s else self._valobj.GetValue()
+        if s is None:
+            return self._valobj.GetValue()
+        else:
+            return '"{}"'.format(s)


### PR DESCRIPTION
<!--- [Issue-XYZ] Add issue number and title to Title above -->

<!-- Add issue link -->
## Summary
<!--- Copy summary from issue link or write a shortened description of it -->
The address is returned when the string is empty

## Fix
<!-- What did you do to fix the issue? -->
If the c string read from memory is not `None`, then format the string and return.

## Pull Request Labels

<!--- While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below: -->

- [ ] has-reproduction
- [ ] feature
- [ ] blocking
- [ ] good first review

<!--- To add a label not listed above, simply place `/label another-label-name` on a line by itself. -->